### PR TITLE
SDL & GLFW Window implementation fixes

### DIFF
--- a/Platforms/GLFW/GLFW_Window.cs
+++ b/Platforms/GLFW/GLFW_Window.cs
@@ -224,7 +224,7 @@ namespace Foster.GLFW
 
         private void OnWindowClose(IntPtr window)
         {
-            GLFW.SetWindowShouldClose(window, false);
+            GLFW.SetWindowShouldClose(window, true);
             OnCloseRequested?.Invoke();
         }
 

--- a/Platforms/SDL2/SDL_System.cs
+++ b/Platforms/SDL2/SDL_System.cs
@@ -92,10 +92,32 @@ namespace Foster.SDL2
                             if (window == null)
                                 continue;
 
-                            if (e.window.windowEvent == SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESIZED)
-                                window.Resized();
-                            else if (e.window.windowEvent == SDL.SDL_WindowEventID.SDL_WINDOWEVENT_CLOSE)
-                                window.CloseRequested();
+                            switch (e.window.windowEvent)
+                            {
+                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESIZED:
+                                    window.Resized();
+                                    break;
+
+                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_CLOSE:
+                                    window.CloseRequested();
+                                    break;
+
+                                // Update visible
+                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_SHOWN:
+                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESTORED:
+                                    window.Restored();
+                                    break;
+                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_HIDDEN:
+                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MINIMIZED:
+                                    window.Minimized();
+                                    break;
+
+                                // Call onFocus
+                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_TAKE_FOCUS:
+                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_FOCUS_GAINED:
+                                    window.FocusGained();
+                                    break;
+                            };
                         }
                         break;
                     

--- a/Platforms/SDL2/SDL_Window.cs
+++ b/Platforms/SDL2/SDL_Window.cs
@@ -321,5 +321,20 @@ namespace Foster.SDL2
         {
             OnCloseRequested?.Invoke();
         }
+
+        public void FocusGained()
+        {
+            OnFocus?.Invoke();
+        }
+
+        public void Minimized()
+        {
+            isVisible = false;
+        }
+
+        public void Restored()
+        {
+            isVisible = true;
+        }
     }
 }


### PR DESCRIPTION
SDL now updates Window.Visible and calls Window.OnFocused

GLFW still closed the window, but if OnCloseRequeseted was not null & called, it didn't for some reason. Now it should do that as well.
Note that GLFW still doesn't update visible (though it calls OnFocused), because I didn't figure that out.