### PR TITLE
Support 16-bit indices + few small things.

### DIFF
--- a/Framework/Graphics/Rendering/Mesh.cs
+++ b/Framework/Graphics/Rendering/Mesh.cs
@@ -16,7 +16,7 @@ namespace Foster.Framework
         {
             protected internal abstract void UploadVertices<T>(ReadOnlySequence<T> vertices, VertexFormat format);
             protected internal abstract void UploadInstances<T>(ReadOnlySequence<T> instances, VertexFormat format);
-            protected internal abstract void UploadIndices(ReadOnlySequence<int> indices);
+            protected internal abstract void UploadIndices<T>(ReadOnlySequence<T> indices);
             protected internal abstract void Dispose();
         }
 
@@ -93,20 +93,20 @@ namespace Foster.Framework
             Implementation.UploadVertices(vertices, VertexFormat);
         }
 
-        public void SetIndices(int[] indices)
+        public void SetIndices<T>(T[] indices)
         {
-            SetIndices(new ReadOnlySequence<int>(indices));
+            SetIndices(new ReadOnlySequence<T>(indices));
         }
 
-        public void SetIndices(ReadOnlyMemory<int> indices)
+        public void SetIndices<T>(ReadOnlyMemory<T> indices)
         {
-            SetIndices(new ReadOnlySequence<int>(indices));
+            SetIndices(new ReadOnlySequence<T>(indices));
         }
 
-        public void SetIndices(ReadOnlySequence<int> indices)
+        public void SetIndices<T>(ReadOnlySequence<T> indices)
         {
             IndexCount = (uint)indices.Length;
-            Implementation.UploadIndices(indices);
+            Implementation.UploadIndices<T>(indices);
         }
 
         public void SetInstances<T>(T[] vertices) where T : struct, IVertex

--- a/Framework/Graphics/Rendering/RenderPass.cs
+++ b/Framework/Graphics/Rendering/RenderPass.cs
@@ -4,12 +4,23 @@ using System.Text;
 
 namespace Foster.Framework
 {
+    public enum IndexElementSize
+    {
+        /// <summary>
+        /// 16-bit short/ushort indices.
+        /// </summary>
+        SixteenBits,
+        /// <summary>
+        /// 32-bit int/uint indices.
+        /// </summary>
+        ThirtyTwoBits
+    }
+
     /// <summary>
     /// A Structure which describes a single Render Pass / Render Call
     /// </summary>
     public struct RenderPass
     {
-
         /// <summary>
         /// Render Target
         /// </summary>
@@ -39,6 +50,11 @@ namespace Foster.Framework
         /// The total number of Indices to draw from the Mesh
         /// </summary>
         public uint MeshIndexCount;
+
+        /// <summary>
+        /// The total number of Indices to draw from the Mesh
+        /// </summary>
+        public IndexElementSize IndexElementSize;
 
         /// <summary>
         /// The total number of Instances to draw from the Mesh
@@ -81,6 +97,7 @@ namespace Foster.Framework
             BlendMode = BlendMode.Normal;
             DepthFunction = Compare.None;
             CullMode = CullMode.None;
+            IndexElementSize = IndexElementSize.ThirtyTwoBits;  // Default to 32 bits.
         }
 
         public void Render()

--- a/Framework/Input/Input.cs
+++ b/Framework/Input/Input.cs
@@ -90,8 +90,13 @@ namespace Foster.Framework
         /// </summary>
         public abstract void SetClipboardString(string value);
 
+        public delegate void TextInputHandler(char value);
+
+        public event TextInputHandler OnTextEvent;
+
         protected void OnText(char value)
         {
+            OnTextEvent.Invoke(value);
             nextState.Keyboard.Text.Append(value);
         }
 

--- a/Platforms/OpenGL/GL_Graphics.cs
+++ b/Platforms/OpenGL/GL_Graphics.cs
@@ -477,16 +477,18 @@ namespace Foster.OpenGL
                         lastPass.Scissor = scissor;
                     }
                 }
+                GLEnum indexType = pass.IndexElementSize == IndexElementSize.ThirtyTwoBits? GLEnum.UNSIGNED_INT: GLEnum.UNSIGNED_SHORT;
+                int indexSize = pass.IndexElementSize == IndexElementSize.ThirtyTwoBits ? sizeof(int) : sizeof(ushort);
 
                 // Draw the Mesh
                 {
                     if (pass.MeshInstanceCount > 0)
                     {
-                        GL.DrawElementsInstanced(GLEnum.TRIANGLES, (int)(pass.MeshIndexCount), GLEnum.UNSIGNED_INT, new IntPtr(sizeof(int) * pass.MeshIndexStart), (int)pass.MeshInstanceCount);
+                        GL.DrawElementsInstanced(GLEnum.TRIANGLES, (int)(pass.MeshIndexCount), indexType, new IntPtr(indexSize * pass.MeshIndexStart), (int)pass.MeshInstanceCount);
                     }
                     else
                     {
-                        GL.DrawElements(GLEnum.TRIANGLES, (int)(pass.MeshIndexCount), GLEnum.UNSIGNED_INT, new IntPtr(sizeof(int) * pass.MeshIndexStart));
+                        GL.DrawElements(GLEnum.TRIANGLES, (int)(pass.MeshIndexCount), indexType, new IntPtr(indexSize * pass.MeshIndexStart));
                     }
 
                     GL.BindVertexArray(0);

--- a/Platforms/OpenGL/GL_Mesh.cs
+++ b/Platforms/OpenGL/GL_Mesh.cs
@@ -57,7 +57,7 @@ namespace Foster.OpenGL
             UploadBuffer(ref instanceBuffer, GLEnum.ARRAY_BUFFER, instances, ref instanceBufferSize);
         }
 
-        protected override unsafe void UploadIndices(ReadOnlySequence<int> indices)
+        protected override unsafe void UploadIndices<T>(ReadOnlySequence<T> indices)
         {
             UploadBuffer(ref indexBuffer, GLEnum.ELEMENT_ARRAY_BUFFER, indices, ref indexBufferSize);
         }

--- a/Platforms/SDL2/SDL_Input.cs
+++ b/Platforms/SDL2/SDL_Input.cs
@@ -365,6 +365,9 @@ namespace Foster.SDL2
             { SDL.SDL_Keycode.SDLK_LALT, Keys.LeftAlt },
             { SDL.SDL_Keycode.SDLK_RCTRL, Keys.RightControl },
             { SDL.SDL_Keycode.SDLK_RSHIFT, Keys.RightShift },
+
+            { SDL.SDL_Keycode.SDLK_LGUI, Keys.LeftSuper },
+            { SDL.SDL_Keycode.SDLK_RGUI, Keys.RightSuper },
         };
     }
 }

--- a/Platforms/Vulkan/VK_Mesh.cs
+++ b/Platforms/Vulkan/VK_Mesh.cs
@@ -9,7 +9,7 @@ namespace Foster.Vulkan
     internal class VK_Mesh : Mesh.Platform
     {
 
-        protected override void UploadIndices(ReadOnlySequence<int> indices)
+        protected override void UploadIndices<T>(ReadOnlySequence<T> indices)
         {
 
         }


### PR DESCRIPTION
The main change here is to add support for 16-bit indices. Dear Imgui provides 16-bit indices to render, and converting from 16-bit to 32-bit (with a C# loop) makes things around 10x slower.

The change is done by adding an `IndexElementSize` enum in RenderPass.cs which selects between 16-bits and 32-bits. `RenderInternal` then uses this to call `DrawElements` properly.

The default `IndexElementSize` is set to 32-bits to ensure backwards compatibility.

Apart from these,

1. Added OnTextEvent event for letting applications handle text input. Useful for ImGui.
2. The macos `cmd` button was missing in the SDL button list, which I added. 