### PR TITLE
JsonObject.Count fix & RectInt.Between (similar to Rect constructor)

### DIFF
--- a/Framework/Spatial/RectInt.cs
+++ b/Framework/Spatial/RectInt.cs
@@ -235,6 +235,18 @@ namespace Foster.Framework
             return $"[{X}, {Y}, {Width}, {Height}]";
         }
 
+        public static RectInt Between(Point2 a, Point2 b)
+        {
+            RectInt rect;
+
+            rect.X = a.X < b.X ? a.X : b.X;
+            rect.Y = a.Y < b.Y ? a.Y : b.Y;
+            rect.Width = (a.X > b.X ? a.X : b.X) - rect.X;
+            rect.Height = (a.Y > b.Y ? a.Y : b.Y) - rect.Y;
+
+            return rect;
+        }
+
         public static bool operator ==(RectInt a, RectInt b)
         {
             return a.X == b.X && a.Y == b.Y && a.Width == b.Width && a.Height == b.Height;

--- a/Json/JsonObject.cs
+++ b/Json/JsonObject.cs
@@ -36,6 +36,7 @@ namespace Foster.Json
         public override IEnumerable<string> Keys => Value.Keys;
         public override IEnumerable<JsonValue> Values => Value.Values;
         public override IEnumerable<KeyValuePair<string, JsonValue>> Pairs => Value;
+        public override int Count => Value.Count;
 
         public override int GetHashedValue()
         {


### PR DESCRIPTION
JsonValue's description of Count suggests that it would also return the Count of KeyValue pairs, but it didn't seem to do that on JsonObject.